### PR TITLE
#1702 removed chromium update popup

### DIFF
--- a/scripts/x86.sh
+++ b/scripts/x86.sh
@@ -28,8 +28,8 @@ chromium http://localhost:8081 \
   --enable-native-gpu-memory-buffers --force-gpu-rasterization --enable-oop-rasterization --enable-zero-copy \
   --autoplay-policy=no-user-gesture-required \
   --disable-pinch \
-  --disable-dev-shm-usage
-
+  --disable-dev-shm-usage \
+  --check-for-update-interval=31449600 --simulate-outdated-no-au='Tue, 31 Dec 2099 23:59:59 GMT'
 
 
 echo "________End of x86.sh________"


### PR DESCRIPTION
Resolves AcmiLabs/xos#1702

Removes chromium update popup following the method used in playlist-label:
"Set chromium-browser update check interval to 1 year, and fake the outdated date to 2099"