### PR TITLE
#51 Use the same settings from Interactive Label for cold boot

### DIFF
--- a/scripts/x86.sh
+++ b/scripts/x86.sh
@@ -2,19 +2,63 @@
 
 echo "________Start of x86.sh________"
 
+# Remove the X server lock file so ours starts cleanly
 rm /tmp/.X0-lock &>/dev/null || true
 
+# Set the display to use
+export DISPLAY=:0
+
+# Set the DBUS address for sending around system messages
+export DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
+
+# Set XDG_RUNTIME_DIR
+mkdir -pv ~/.cache/xdgr
+export XDG_RUNTIME_DIR=$PATH:~/.cache/xdgr
+
+# Create Xauthority
+touch /root/.Xauthority
+
+# Start desktop manager
+echo "Starting X"
 startx -- -nocursor &
+
+# TODO: work out how to detect X has started
 sleep 10
 
-#unclutter -display :0 -idle 0.1 &
+# Print all of the current displays used by running processes
+echo "Displays in use after starting X"
+DISPLAYS=`ps -u $(id -u) -o pid= | \
+  while read pid; do
+    cat /proc/$pid/environ 2>/dev/null | tr '\0' '\n' | grep '^DISPLAY=:'
+  done | sort -u`
+echo $DISPLAYS
 
+# If DISPLAYS doesn't include 0.0 set the new display
+if [[ $DISPLAYS == *"0.0"* ]]; then
+  echo "Display includes 0.0 so let's launch..."
+else
+  LAST_DISPLAY=`ps -u $(id -u) -o pid= | \
+    while read pid; do
+      cat /proc/$pid/environ 2>/dev/null | tr '\0' '\n' | grep '^DISPLAY=:'
+    done | sort -u | tail -n1`
+  echo "0.0 is missing, so setting display to: ${LAST_DISPLAY}"
+  export $LAST_DISPLAY
+fi
+
+# Prevent blanking and screensaver
+xset s off -dpms
+
+# Hide the cursor
+unclutter -idle 0.1 &
+
+# Rotate display
 xrandr -o left
 
+# Turn off speaker, and turn on headphone audio
 amixer sset Speaker off
 amixer sset Master 100% on
 
-
+# Start Spotlights app
 python -u -m app.cache
 python -u -m app.main &
 
@@ -31,5 +75,12 @@ chromium http://localhost:8081 \
   --disable-dev-shm-usage \
   --check-for-update-interval=31449600 --simulate-outdated-no-au='Tue, 31 Dec 2099 23:59:59 GMT'
 
+# For debugging
+echo "Chromium browser exited unexpectedly."
+free -h
+
+# Restart the container
+echo "Restarting container..."
+curl -H "Content-Type: application/json" -d "{\"serviceName\": \"$BALENA_SERVICE_NAME\"}" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/restart-service?apikey=$BALENA_SUPERVISOR_API_KEY"
 
 echo "________End of x86.sh________"


### PR DESCRIPTION
Resolves #51

Use the same settings from Interactive Label to attempt to set the correct DISPLAY, and if Chromium fails restart the container.

### Acceptance Criteria
- [x] Catch failure to set `DISPLAY` on cold boot, restart container

### Relevant design files
* None

### Testing instructions
1. See that [DD-00-AV07-PC01](https://dashboard.balena-cloud.com/devices/839c8b3a6fba54e2fbc0e19c091b3bf8/summary) reboots/cold boots successfully.

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~
