### PR TITLE
utf8 subs

### DIFF
--- a/app/static/index.js
+++ b/app/static/index.js
@@ -54,7 +54,11 @@ const playlist_content = window.playlist_labels.map(function r(x) {
     style2: x.label.columns[2].style,
     video_url: x.resource,
     image_url: x.image,
-    subtitles: x.subtitles ? URL.createObjectURL(new Blob([x.subtitles], {type: 'text/vtt; charset=UTF-8'})) : ''
+    subtitles: x.subtitles
+      ? URL.createObjectURL(
+          new Blob([x.subtitles], { type: "text/vtt; charset=UTF-8" })
+        )
+      : ""
   };
 });
 

--- a/tests/js/__tests__/spotlights.test.js
+++ b/tests/js/__tests__/spotlights.test.js
@@ -1,3 +1,5 @@
+window.URL.createObjectURL = function createObjectURL() {};
+
 global.EventSource = function dummyEventSource() {};
 global.playlist_labels = require("../../data/playlist.json").playlist_labels;
 


### PR DESCRIPTION
Resolves #63

Supports UTF-8 in subtitles by creating a js Blob instead of a base64 data-url.

### Acceptance Criteria
Replace acceptance criteria with the acceptance criteria in the ticket or check the box if none.
- [x] No acceptance criteria on the issue

### Relevant design files
Add a links to the relevant design files or leave as none.
* None

### Testing instructions
Add a list of steps required to test the feature.
1. Add a utf-8 character like ” to the subtitles and see they display.

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
- [x] Changelog has been updated if necessary
- [x] Deployment / migration instruction have been updated if required
