### PR TITLE
#75 Add 30 seconds sleep before performing the spotlights first boot container restart

### DIFF
--- a/scripts/first_boot.sh
+++ b/scripts/first_boot.sh
@@ -7,7 +7,8 @@ BOOT_COUNT=$(echo $BOOT_COUNT_RESPONSE | jq --raw-output '.count')
 
 if [[ $BOOT_COUNT == "1" ]]; then
   # Restart the container
-  echo "This is the first boot, so restarting the spotlights container to resolve the lack of touch input..."
+  echo "This is the first boot, so restarting the spotlights container in 30 seconds to resolve the lack of touch input..."
+  sleep 30
   # Update the boot count
   curl --request POST 'http://bootcount:8082/api/count/'
   # Restart the spotlights container


### PR DESCRIPTION
Resolves #75

Add 30 seconds sleep before performing the spotlights first boot container restart.

### Acceptance Criteria
- [x] Wait 30 seconds before restarting the spotlights container to give the touchscreen time to start up

### Relevant design files
* None

### Testing instructions
1. None

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~
