### PR TITLE
#56 Fix handling of the XOS Tap response JSON when passing it back to the Lens Reader

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -129,7 +129,7 @@ def collect_item():
     response = requests.post(xos_tap_endpoint, json=xos_tap, headers=headers)
     if response.status_code != requests.codes['created']:
         raise HTTPError('Could not save tap to XOS.')
-    return jsonify(response.content), response.status_code
+    return response.json(), response.status_code
 
 
 def event_stream():

--- a/tests/data/xos_tap.json
+++ b/tests/data/xos_tap.json
@@ -1,21 +1,60 @@
 {
-  "id": 26775,
-  "nfc_tag": {
-    "atr": "",
-    "uid": "lensuid",
-    "short_code": "nbadbb"
-  },
+  "id": 981363,
+  "tap_datetime": "2021-04-09T10:27:50.310975+10:00",
+  "created_at": "2021-04-09T10:27:52.104253+10:00",
+  "lens_hash": "ef...dc",
+  "lens_short_code": "lens12",
   "experience_id": null,
-  "tap_datetime": "2019-10-22T12:47:04.347477+11:00",
-  "created_at": "2019-10-22T12:47:04.512503+11:00",
-  "data": {
-    "nfc_reader": {
-      "mac_address": "00:00:00:00:00:00",
-      "reader_ip": "127.0.0.666",
-      "reader_model": "IDTech Kiosk IV",
-      "reader_name": "nfc-666"
-    }
-  },
   "maker_moment": null,
-  "label": 1
+  "collectible": {
+    "id": 57404,
+    "acmi_id": "183866",
+    "title": "",
+    "thumbnail": {
+      "image_url": "https://.s3.amazonaws.com/media/image.jpg",
+      "animated_image_url": "",
+      "has_video": true
+    },
+    "slug": "warwick-thornton",
+    "type": "Film",
+    "work": {
+      "id": 117910,
+      "acmi_id": "183866",
+      "title": "Spotlights: Warwick Thornton",
+      "title_annotation": "",
+      "slug": "spotlights-warwick-thornton",
+      "creator_credit": "",
+      "credit_line": "",
+      "headline_credit": "",
+      "thumbnail": {
+        "image_url": "https://.s3.amazonaws.com/media/image.jpg",
+        "animated_image_url": "",
+        "has_video": true
+      },
+      "record_type": "work",
+      "type": "Film",
+      "is_on_display": true,
+      "last_on_display_place": "ACMI: Gallery 1",
+      "last_on_display_date": "2031-02-16",
+      "is_context_indigenous": false,
+      "material_description": "",
+      "unpublished": false,
+      "first_production_date": null,
+      "brief_description": "<p>A Kaytetye man born and raised in Alice Springs. A film director, screenwriter and cinematographer, his debut feature film Samson and Delilah won the Caméra d&#8217;Or at the 2009 Cannes Film Festival. He also won the Asia Pacific Screen Award for Best Film in 2017 for Sweet Country.</p>",
+      "constellations_primary": [],
+      "constellations_other": [],
+      "recommendations": []
+    },
+    "is_an_event": false,
+    "url_override": ""
+  },
+  "data": {
+    "lens_reader": {
+      "device_name": "si-tap-reader",
+      "mac_address": "00:00:00:00:00:00",
+      "reader_ip": "127.0.0.1",
+      "reader_model": "IDTech Kiosk IV"
+    },
+    "playlist_info": { "datetime": "1617928066827", "playlist_id": 156 }
+  }
 }

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -83,7 +83,7 @@ def test_route_collect_item(client):
         lens_tap_data = taps_file.read()
 
     response = client.post('/api/taps/', data=lens_tap_data, headers={'Content-Type': 'application/json'})
-    assert response.json["nfc_tag"]["short_code"] == "nbadbb"
+    assert response.json["lens_short_code"] == "lens12"
     assert response.status_code == 201
 
 


### PR DESCRIPTION
Resolves #56

Pass the XOS Tap JSON to the Flask serializer rather than the body content to avoid the exception.

### Acceptance Criteria
- [x] Pass `response.json()` to the Flask serializer rather than `response.content`

### Relevant design files
* None

### Testing instructions
1. In `config.env` set `XOS_PLAYLIST_ID=156`
1. Start spotlights with: `cd development` and `docker-compose up`
1. Point your test Lens Reader to the API of your dev laptop. e.g. http://192.168.1.2:8081/api/
1. Tap on the Lens Reader and see that you get a success LED response, and no exception in the Spotlights logs

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
- [ ] Changelog has been updated if necessary
~- [ ] Deployment / migration instruction have been updated if required~
